### PR TITLE
Added FAQ item

### DIFF
--- a/docs/content/faq/_index.md
+++ b/docs/content/faq/_index.md
@@ -391,6 +391,12 @@ The Bicep VSCode extension is reading metadata through [this JSON file](https://
 
 ---
 
+### Do I need to allow a specific URL to access the Public Registry?
+
+In a regulated environment, network traffic might be limited, especially when using private build agents. The AVM Bicep templates are served from the Microsoft Container Registry. To access this container registry, the URL [https://mcr.microsoft.com](https://mcr.microsoft.com) must be accessible from the network. So, if your network settings or firewall rules prevent access to this URL, you would need to allow it to ensure proper functioning.
+
+---
+
 ### Aren't AVM resource modules too complex for people less skilled in IaC technologies?
 
  **TLDR**: Resource modules have complexity inside, so they can be flexibly used from the outside.


### PR DESCRIPTION
# Overview/Summary

In regulated environments (for example, my current customer: government), there are strict rules on network traffic. In the case of AVM, network traffic to the internet is required to reach the Microsoft Container Registry. Most customers run private build agents. These agents must be allowed to access mcr.microsoft.com in order to successfully resolve the AVM module during the deployment process.

## This PR fixes/adds/changes/removes

This pull request adds an item on the FAQ list. 

### Breaking Changes

None

## As part of this Pull Request I have

- [x] Read the Contribution Guide and ensured this PR is compliant with the guide
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/Azure-Verified-Modules/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/Azure-Verified-Modules/issues) or ADO Work Items (Internal Only)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/Azure-Verified-Modules/)
- [ ] Ensured PR tests are passing
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Docs etc.)
